### PR TITLE
Fix bunk neighbourhood record of Sydney

### DIFF
--- a/data/101/932/003/101932003.geojson
+++ b/data/101/932/003/101932003.geojson
@@ -398,9 +398,9 @@
     "wof:belongsto":[
         85681545,
         102191583,
-        85632793,
-        404226357,
         1376953385,
+        404226357,
+        85632793,
         136253039,
         102049151
     ],
@@ -439,14 +439,16 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1550792797,
+    "wof:lastmodified":1560203341,
     "wof:name":"Sydney",
     "wof:parent_id":404226357,
     "wof:placetype":"locality",
     "wof:population":4840600,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-au",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        85771099
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/101/932/003/101932003.geojson
+++ b/data/101/932/003/101932003.geojson
@@ -439,17 +439,17 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1560203341,
+    "wof:lastmodified":1560296115,
     "wof:name":"Sydney",
     "wof:parent_id":404226357,
     "wof:placetype":"locality",
     "wof:population":4840600,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-au",
-    "wof:superseded_by":[
+    "wof:superseded_by":[],
+    "wof:supersedes":[
         85771099
     ],
-    "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/857/710/99/85771099.geojson
+++ b/data/857/710/99/85771099.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-06-10",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -19,7 +20,7 @@
     "mps:latitude":-34.036118,
     "mps:longitude":151.192204,
     "mz:hierarchy_label":0,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:is_funky":1,
     "mz:is_hard_boundary":0,
     "mz:is_landuse_aoi":0,
@@ -518,16 +519,14 @@
         }
     ],
     "wof:id":85771099,
-    "wof:lastmodified":1551831344,
-    "wof:megacity":1,
+    "wof:lastmodified":1560203345,
     "wof:name":"Sydney",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
-    "wof:population":4627345,
-    "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-au",
-    "wof:scale":1,
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        101932003
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1251

- Deprecates erroneous Sydney neighbourhood record, flagging it as is_current = 0 and superseding it into the Sydney locality
- Removes erroneous `mz:*` properties from the neighbourhood record

No PIP work required, can merge once approved.