### PR TITLE
Updated labels in AU

### DIFF
--- a/data/102/048/423/102048423.geojson
+++ b/data/102/048/423/102048423.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-26.841559,
     "geom:longitude":150.347316,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Western Downs Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-26.879382,
     "lbl:longitude":150.434924,
     "mps:latitude":-26.879382,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048423,
-    "wof:lastmodified":1550728241,
+    "wof:lastmodified":1560814016,
     "wof:name":"Western Downs",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/048/439/102048439.geojson
+++ b/data/102/048/439/102048439.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-9.858449,
     "geom:longitude":142.366729,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Torres Strait Island Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-10.181578,
     "lbl:longitude":142.26641,
     "mps:latitude":-10.181578,
@@ -37,9 +43,9 @@
     "wof:belongs_to":[],
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -55,7 +61,7 @@
         }
     ],
     "wof:id":102048439,
-    "wof:lastmodified":1550728339,
+    "wof:lastmodified":1560814017,
     "wof:name":"Torres Strait Island",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/048/461/102048461.geojson
+++ b/data/102/048/461/102048461.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-12.640446,
     "geom:longitude":141.878904,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Weipa Town"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "town"
+    ],
     "lbl:latitude":-12.6354,
     "lbl:longitude":141.870774,
     "mps:latitude":-12.6354,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048461,
-    "wof:lastmodified":1550728457,
+    "wof:lastmodified":1560814023,
     "wof:name":"Weipa",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/048/467/102048467.geojson
+++ b/data/102/048/467/102048467.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-42.212346,
     "geom:longitude":146.646058,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Central Highlands Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-42.195807,
     "lbl:longitude":146.658088,
     "mps:latitude":-42.195807,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681583,
         85632793,
-        136253039,
-        85681583
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048467,
-    "wof:lastmodified":1550728574,
+    "wof:lastmodified":1560814021,
     "wof:name":"Central Highlands",
     "wof:parent_id":85681583,
     "wof:placetype":"county",

--- a/data/102/048/469/102048469.geojson
+++ b/data/102/048/469/102048469.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.41773,
     "geom:longitude":149.455678,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Upper Lachlan Shire Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-34.358541,
     "lbl:longitude":149.406476,
     "mps:latitude":-34.358541,
@@ -55,9 +61,9 @@
     "wd:wordcount":240,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102048469,
-    "wof:lastmodified":1550728658,
+    "wof:lastmodified":1560814022,
     "wof:name":"Upper Lachlan Shire",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/048/493/102048493.geojson
+++ b/data/102/048/493/102048493.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.969228,
     "geom:longitude":150.726591,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Upper Hunter Shire Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-31.897927,
     "lbl:longitude":151.101188,
     "mps:latitude":-31.897927,
@@ -55,9 +61,9 @@
     "wd:wordcount":775,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102048493,
-    "wof:lastmodified":1550728757,
+    "wof:lastmodified":1560814021,
     "wof:name":"Upper Hunter Shire",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/048/519/102048519.geojson
+++ b/data/102/048/519/102048519.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-17.150289,
     "geom:longitude":144.19576,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Tablelands Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-17.175462,
     "lbl:longitude":144.595107,
     "mps:latitude":-17.175462,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048519,
-    "wof:lastmodified":1550728968,
+    "wof:lastmodified":1560814019,
     "wof:name":"Tablelands",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/048/537/102048537.geojson
+++ b/data/102/048/537/102048537.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.002534,
     "geom:longitude":117.661341,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Broomehill-Tambellup Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-33.9789,
     "lbl:longitude":117.654879,
     "mps:latitude":-33.9789,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681439,
         85632793,
-        136253039,
-        85681439
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048537,
-    "wof:lastmodified":1550729049,
+    "wof:lastmodified":1560814020,
     "wof:name":"Broomehill-Tambellup",
     "wof:parent_id":85681439,
     "wof:placetype":"county",

--- a/data/102/048/629/102048629.geojson
+++ b/data/102/048/629/102048629.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-41.243983,
     "geom:longitude":146.560022,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Latrobe Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-41.236204,
     "lbl:longitude":146.487803,
     "mps:latitude":-41.236204,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681583,
         85632793,
-        136253039,
-        85681583
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048629,
-    "wof:lastmodified":1550731193,
+    "wof:lastmodified":1560814016,
     "wof:name":"Latrobe",
     "wof:parent_id":85681583,
     "wof:placetype":"county",

--- a/data/102/048/635/102048635.geojson
+++ b/data/102/048/635/102048635.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.827657,
     "geom:longitude":146.262864,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Corowa Shire Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-35.814629,
     "lbl:longitude":146.25549,
     "mps:latitude":-35.814629,
@@ -55,9 +61,9 @@
     "wd:wordcount":282,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102048635,
-    "wof:lastmodified":1550731206,
+    "wof:lastmodified":1560814018,
     "wof:name":"Corowa Shire",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/048/659/102048659.geojson
+++ b/data/102/048/659/102048659.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.55062,
     "geom:longitude":150.438424,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Liverpool Plains Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-31.605759,
     "lbl:longitude":150.525984,
     "mps:latitude":-31.605759,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048659,
-    "wof:lastmodified":1550731624,
+    "wof:lastmodified":1560814018,
     "wof:name":"Liverpool Plains",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/048/715/102048715.geojson
+++ b/data/102/048/715/102048715.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-28.561465,
     "geom:longitude":115.500416,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "City of Greater Geraldton"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "city"
+    ],
     "lbl:latitude":-28.576209,
     "lbl:longitude":115.570948,
     "mps:latitude":-28.576209,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681439,
         85632793,
-        136253039,
-        85681439
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048715,
-    "wof:lastmodified":1550732606,
+    "wof:lastmodified":1560814020,
     "wof:name":"Greater Geraldton",
     "wof:parent_id":85681439,
     "wof:placetype":"county",

--- a/data/102/048/785/102048785.geojson
+++ b/data/102/048/785/102048785.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-30.892496,
     "geom:longitude":150.907039,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Tamworth Regional Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-30.889343,
     "lbl:longitude":150.907218,
     "mps:latitude":-30.889343,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048785,
-    "wof:lastmodified":1550733264,
+    "wof:lastmodified":1560814019,
     "wof:name":"Tamworth Regional",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/048/801/102048801.geojson
+++ b/data/102/048/801/102048801.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-42.269214,
     "geom:longitude":147.965341,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Glamorgan/Spring Bay Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-41.980375,
     "lbl:longitude":147.983242,
     "mps:latitude":-41.980375,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681583,
         85632793,
-        136253039,
-        85681583
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048801,
-    "wof:lastmodified":1550733876,
+    "wof:lastmodified":1560814023,
     "wof:name":"Glamorgan/Spring Bay",
     "wof:parent_id":85681583,
     "wof:placetype":"county",

--- a/data/102/048/811/102048811.geojson
+++ b/data/102/048/811/102048811.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-18.731239,
     "geom:longitude":146.600458,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Palm Island Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-18.733052,
     "lbl:longitude":146.606757,
     "mps:latitude":-18.733052,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048811,
-    "wof:lastmodified":1550733899,
+    "wof:lastmodified":1560814015,
     "wof:name":"Palm Island",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/048/827/102048827.geojson
+++ b/data/102/048/827/102048827.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.876039,
     "geom:longitude":149.813491,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Goulburn Mulwaree Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-34.898259,
     "lbl:longitude":149.784089,
     "mps:latitude":-34.898259,
@@ -55,9 +61,9 @@
     "wd:wordcount":413,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102048827,
-    "wof:lastmodified":1550734582,
+    "wof:lastmodified":1560814015,
     "wof:name":"Goulburn Mulwaree",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/048/829/102048829.geojson
+++ b/data/102/048/829/102048829.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-15.435604,
     "geom:longitude":134.652593,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Roper Gulf Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-15.274022,
     "lbl:longitude":134.09789,
     "mps:latitude":-15.274022,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681533,
         85632793,
-        136253039,
-        85681533
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048829,
-    "wof:lastmodified":1550734634,
+    "wof:lastmodified":1560814015,
     "wof:name":"Roper Gulf",
     "wof:parent_id":85681533,
     "wof:placetype":"county",

--- a/data/102/048/835/102048835.geojson
+++ b/data/102/048/835/102048835.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-29.681742,
     "geom:longitude":152.751149,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Clarence Valley Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-29.717009,
     "lbl:longitude":152.760303,
     "mps:latitude":-29.717009,
@@ -37,9 +43,9 @@
     "wd:wordcount":800,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,7 +63,7 @@
         }
     ],
     "wof:id":102048835,
-    "wof:lastmodified":1550734780,
+    "wof:lastmodified":1560814017,
     "wof:name":"Clarence Valley",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/048/837/102048837.geojson
+++ b/data/102/048/837/102048837.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.907574,
     "geom:longitude":138.63645,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "City of Norwood Payneham St Peters"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "city"
+    ],
     "lbl:latitude":-34.902026,
     "lbl:longitude":138.636882,
     "mps:latitude":-34.902026,
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":102048837,
-    "wof:lastmodified":1550734783,
+    "wof:lastmodified":1560814023,
     "wof:name":"Norwood Payneham St Peters",
     "wof:parent_id":1376953367,
     "wof:placetype":"county",

--- a/data/102/048/847/102048847.geojson
+++ b/data/102/048/847/102048847.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.936475,
     "geom:longitude":117.172044,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Narrogin Town"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "town"
+    ],
     "lbl:latitude":-32.93843,
     "lbl:longitude":117.171594,
     "mps:latitude":-32.93843,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681439,
         85632793,
-        136253039,
-        85681439
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048847,
-    "wof:lastmodified":1550734819,
+    "wof:lastmodified":1560814020,
     "wof:name":"Narrogin",
     "wof:parent_id":85681439,
     "wof:placetype":"county",

--- a/data/102/048/861/102048861.geojson
+++ b/data/102/048/861/102048861.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-26.405233,
     "geom:longitude":151.646929,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "South Burnett Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-26.351575,
     "lbl:longitude":151.558995,
     "mps:latitude":-26.351575,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048861,
-    "wof:lastmodified":1550734926,
+    "wof:lastmodified":1560814017,
     "wof:name":"South Burnett",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/048/883/102048883.geojson
+++ b/data/102/048/883/102048883.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.713827,
     "geom:longitude":139.76141,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "The Coorong Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-35.697131,
     "lbl:longitude":139.739779,
     "mps:latitude":-35.697131,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681519,
         85632793,
-        136253039,
-        85681519
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":102048883,
-    "wof:lastmodified":1550735028,
+    "wof:lastmodified":1560814020,
     "wof:name":"The Coorong",
     "wof:parent_id":85681519,
     "wof:placetype":"county",

--- a/data/102/048/887/102048887.geojson
+++ b/data/102/048/887/102048887.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.083392,
     "geom:longitude":150.845798,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "City of Campbelltown"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "city"
+    ],
     "lbl:latitude":-34.097815,
     "lbl:longitude":150.847769,
     "mps:latitude":-34.097815,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048887,
-    "wof:lastmodified":1550735035,
+    "wof:lastmodified":1560814015,
     "wof:name":"Campbelltown",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/048/909/102048909.geojson
+++ b/data/102/048/909/102048909.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-29.328877,
     "geom:longitude":130.938926,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Maralinga Tjarutja Aboriginal Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "aboriginal council"
+    ],
     "lbl:latitude":-29.189821,
     "lbl:longitude":130.644952,
     "mps:latitude":-29.189821,
@@ -52,9 +58,9 @@
     "wd:wordcount":939,
     "wof:belongsto":[
         102191583,
+        85681519,
         85632793,
-        136253039,
-        85681519
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -70,7 +76,7 @@
         }
     ],
     "wof:id":102048909,
-    "wof:lastmodified":1550735216,
+    "wof:lastmodified":1560814014,
     "wof:name":"Maralinga Tjarutja",
     "wof:parent_id":85681519,
     "wof:placetype":"county",

--- a/data/102/048/913/102048913.geojson
+++ b/data/102/048/913/102048913.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-24.637325,
     "geom:longitude":133.161639,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "MacDonnell Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-24.508519,
     "lbl:longitude":132.411721,
     "mps:latitude":-24.508519,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681533,
         85632793,
-        136253039,
-        85681533
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048913,
-    "wof:lastmodified":1550735241,
+    "wof:lastmodified":1560814020,
     "wof:name":"MacDonnell",
     "wof:parent_id":85681533,
     "wof:placetype":"county",

--- a/data/102/048/935/102048935.geojson
+++ b/data/102/048/935/102048935.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-11.004957,
     "geom:longitude":142.312954,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Northern Peninsula Area Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-11.052149,
     "lbl:longitude":142.266587,
     "mps:latitude":-11.052149,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048935,
-    "wof:lastmodified":1550735319,
+    "wof:lastmodified":1560814020,
     "wof:name":"Northern Peninsula Area",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/048/945/102048945.geojson
+++ b/data/102/048/945/102048945.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-28.061976,
     "geom:longitude":152.796512,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Scenic Rim Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-28.096082,
     "lbl:longitude":152.788409,
     "mps:latitude":-28.096082,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048945,
-    "wof:lastmodified":1550735415,
+    "wof:lastmodified":1560814026,
     "wof:name":"Scenic Rim",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/048/951/102048951.geojson
+++ b/data/102/048/951/102048951.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-19.443804,
     "geom:longitude":135.085422,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Barkly Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-19.260467,
     "lbl:longitude":135.085988,
     "mps:latitude":-19.260467,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681533,
         85632793,
-        136253039,
-        85681533
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048951,
-    "wof:lastmodified":1550735436,
+    "wof:lastmodified":1560814020,
     "wof:name":"Barkly",
     "wof:parent_id":85681533,
     "wof:placetype":"county",

--- a/data/102/048/963/102048963.geojson
+++ b/data/102/048/963/102048963.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-28.405602,
     "geom:longitude":151.88568,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Southern Downs Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-28.267698,
     "lbl:longitude":151.941465,
     "mps:latitude":-28.267698,
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":102048963,
-    "wof:lastmodified":1550735507,
+    "wof:lastmodified":1560814014,
     "wof:name":"Southern Downs",
     "wof:parent_id":1376953409,
     "wof:placetype":"county",

--- a/data/102/048/979/102048979.geojson
+++ b/data/102/048/979/102048979.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.023996,
     "geom:longitude":135.336363,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Wudinna Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-32.977534,
     "lbl:longitude":135.27944,
     "mps:latitude":-32.977534,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681519,
         85632793,
-        136253039,
-        85681519
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048979,
-    "wof:lastmodified":1550735618,
+    "wof:lastmodified":1560814019,
     "wof:name":"Wudinna",
     "wof:parent_id":85681519,
     "wof:placetype":"county",

--- a/data/102/048/983/102048983.geojson
+++ b/data/102/048/983/102048983.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-41.38284,
     "geom:longitude":145.495751,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Waratah/Wynyard Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-41.450732,
     "lbl:longitude":145.424852,
     "mps:latitude":-41.450732,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681583,
         85632793,
-        136253039,
-        85681583
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102048983,
-    "wof:lastmodified":1550735815,
+    "wof:lastmodified":1560814018,
     "wof:name":"Waratah/Wynyard",
     "wof:parent_id":85681583,
     "wof:placetype":"county",

--- a/data/102/049/015/102049015.geojson
+++ b/data/102/049/015/102049015.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.732347,
     "geom:longitude":144.742022,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Murray Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-35.752351,
     "lbl:longitude":144.697706,
     "mps:latitude":-35.752351,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049015,
-    "wof:lastmodified":1550736112,
+    "wof:lastmodified":1560814027,
     "wof:name":"Murray",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/049/025/102049025.geojson
+++ b/data/102/049/025/102049025.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-12.143715,
     "geom:longitude":141.919764,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Mapoon Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-12.115655,
     "lbl:longitude":141.854636,
     "mps:latitude":-12.115655,
@@ -46,9 +52,9 @@
     "wd:wordcount":647,
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +72,7 @@
         }
     ],
     "wof:id":102049025,
-    "wof:lastmodified":1550736152,
+    "wof:lastmodified":1560814029,
     "wof:name":"Mapoon",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/033/102049033.geojson
+++ b/data/102/049/033/102049033.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-27.642732,
     "geom:longitude":152.240527,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Lockyer Valley Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-27.62106,
     "lbl:longitude":152.234962,
     "mps:latitude":-27.62106,
@@ -40,9 +46,9 @@
     "wd:wordcount":1395,
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -60,7 +66,7 @@
         }
     ],
     "wof:id":102049033,
-    "wof:lastmodified":1550736181,
+    "wof:lastmodified":1560814037,
     "wof:name":"Lockyer Valley",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/051/102049051.geojson
+++ b/data/102/049/051/102049051.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-11.560003,
     "geom:longitude":130.816215,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Tiwi Islands Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-11.589828,
     "lbl:longitude":131.047818,
     "mps:latitude":-11.589828,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681533,
         85632793,
-        136253039,
-        85681533
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049051,
-    "wof:lastmodified":1550736306,
+    "wof:lastmodified":1560814040,
     "wof:name":"Tiwi Islands",
     "wof:parent_id":85681533,
     "wof:placetype":"county",

--- a/data/102/049/053/102049053.geojson
+++ b/data/102/049/053/102049053.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-25.355265,
     "geom:longitude":151.204029,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "North Burnett Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-25.428567,
     "lbl:longitude":151.139209,
     "mps:latitude":-25.428567,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049053,
-    "wof:lastmodified":1550736336,
+    "wof:lastmodified":1560814030,
     "wof:name":"North Burnett",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/081/102049081.geojson
+++ b/data/102/049/081/102049081.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-26.544286,
     "geom:longitude":148.287363,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Maranoa Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-26.635075,
     "lbl:longitude":148.259593,
     "mps:latitude":-26.635075,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":102049081,
-    "wof:lastmodified":1550736511,
+    "wof:lastmodified":1560814036,
     "wof:name":"Maranoa",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/131/102049131.geojson
+++ b/data/102/049/131/102049131.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-27.118292,
     "geom:longitude":152.88242,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Moreton Bay Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-27.119285,
     "lbl:longitude":152.884703,
     "mps:latitude":-27.119285,
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":102049131,
-    "wof:lastmodified":1550737034,
+    "wof:lastmodified":1560814033,
     "wof:name":"Moreton Bay",
     "wof:parent_id":1376953397,
     "wof:placetype":"county",

--- a/data/102/049/139/102049139.geojson
+++ b/data/102/049/139/102049139.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.594989,
     "geom:longitude":150.964252,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "The Hills Shire Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-33.638277,
     "lbl:longitude":150.958048,
     "mps:latitude":-33.638277,
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":102049139,
-    "wof:lastmodified":1550737071,
+    "wof:lastmodified":1560814035,
     "wof:name":"The Hills Shire",
     "wof:parent_id":1376953385,
     "wof:placetype":"county",

--- a/data/102/049/147/102049147.geojson
+++ b/data/102/049/147/102049147.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-12.507816,
     "geom:longitude":133.258732,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "West Arnhem Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-12.429717,
     "lbl:longitude":133.240075,
     "mps:latitude":-12.429717,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681533,
         85632793,
-        136253039,
-        85681533
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049147,
-    "wof:lastmodified":1550737131,
+    "wof:lastmodified":1560814047,
     "wof:name":"West Arnhem",
     "wof:parent_id":85681533,
     "wof:placetype":"county",

--- a/data/102/049/157/102049157.geojson
+++ b/data/102/049/157/102049157.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.643517,
     "geom:longitude":140.02551,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Kingston Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-36.66234,
     "lbl:longitude":140.0515,
     "mps:latitude":-36.66234,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681519,
         85632793,
-        136253039,
-        85681519
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049157,
-    "wof:lastmodified":1550739169,
+    "wof:lastmodified":1560814026,
     "wof:name":"Kingston",
     "wof:parent_id":85681519,
     "wof:placetype":"county",

--- a/data/102/049/175/102049175.geojson
+++ b/data/102/049/175/102049175.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-24.789426,
     "geom:longitude":145.791377,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Blackall Tambo Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-24.801153,
     "lbl:longitude":145.700907,
     "mps:latitude":-24.801153,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049175,
-    "wof:lastmodified":1550739508,
+    "wof:lastmodified":1560814032,
     "wof:name":"Blackall Tambo",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/183/102049183.geojson
+++ b/data/102/049/183/102049183.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-21.489832,
     "geom:longitude":132.415292,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Central Desert Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-21.490169,
     "lbl:longitude":130.980013,
     "mps:latitude":-21.490169,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681533,
         85632793,
-        136253039,
-        85681533
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049183,
-    "wof:lastmodified":1550739525,
+    "wof:lastmodified":1560814047,
     "wof:name":"Central Desert",
     "wof:parent_id":85681533,
     "wof:placetype":"county",

--- a/data/102/049/201/102049201.geojson
+++ b/data/102/049/201/102049201.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-12.933495,
     "geom:longitude":135.744865,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "East Arnhem Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-12.865721,
     "lbl:longitude":135.547783,
     "mps:latitude":-12.865721,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681533,
         85632793,
-        136253039,
-        85681533
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049201,
-    "wof:lastmodified":1550739819,
+    "wof:lastmodified":1560814037,
     "wof:name":"East Arnhem",
     "wof:parent_id":85681533,
     "wof:placetype":"county",

--- a/data/102/049/203/102049203.geojson
+++ b/data/102/049/203/102049203.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.409811,
     "geom:longitude":152.531244,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Port Macquarie-Hastings Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-31.406676,
     "lbl:longitude":152.567989,
     "mps:latitude":-31.406676,
@@ -55,9 +61,9 @@
     "wd:wordcount":1449,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102049203,
-    "wof:lastmodified":1550739836,
+    "wof:lastmodified":1560814030,
     "wof:name":"Port Macquarie-Hastings",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/049/215/102049215.geojson
+++ b/data/102/049/215/102049215.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.977255,
     "geom:longitude":140.547354,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Naracoorte and Lucindale Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-36.956992,
     "lbl:longitude":140.494474,
     "mps:latitude":-36.956992,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681519,
         85632793,
-        136253039,
-        85681519
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049215,
-    "wof:lastmodified":1550740016,
+    "wof:lastmodified":1560814036,
     "wof:name":"Naracoorte and Lucindale",
     "wof:parent_id":85681519,
     "wof:placetype":"county",

--- a/data/102/049/217/102049217.geojson
+++ b/data/102/049/217/102049217.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-16.081245,
     "geom:longitude":130.60884,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Victoria-Daly Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-16.333764,
     "lbl:longitude":130.575422,
     "mps:latitude":-16.333764,
@@ -46,9 +52,9 @@
     "wd:wordcount":284,
     "wof:belongsto":[
         102191583,
+        85681533,
         85632793,
-        136253039,
-        85681533
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +73,7 @@
         }
     ],
     "wof:id":102049217,
-    "wof:lastmodified":1550740027,
+    "wof:lastmodified":1560814029,
     "wof:name":"Victoria-Daly",
     "wof:parent_id":85681533,
     "wof:placetype":"county",

--- a/data/102/049/233/102049233.geojson
+++ b/data/102/049/233/102049233.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.376842,
     "geom:longitude":138.105932,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Port Pirie City and Dists Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-33.323977,
     "lbl:longitude":138.076886,
     "mps:latitude":-33.323977,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681519,
         85632793,
-        136253039,
-        85681519
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049233,
-    "wof:lastmodified":1550740293,
+    "wof:lastmodified":1560814031,
     "wof:name":"Port Pirie City and Dists",
     "wof:parent_id":85681519,
     "wof:placetype":"county",

--- a/data/102/049/237/102049237.geojson
+++ b/data/102/049/237/102049237.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-17.959402,
     "geom:longitude":145.925811,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Cassowary Coast Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-17.902141,
     "lbl:longitude":145.889179,
     "mps:latitude":-17.902141,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049237,
-    "wof:lastmodified":1550740340,
+    "wof:lastmodified":1560814038,
     "wof:name":"Cassowary Coast",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/239/102049239.geojson
+++ b/data/102/049/239/102049239.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.587003,
     "geom:longitude":146.023762,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Benalla Rural City"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "rural city"
+    ],
     "lbl:latitude":-36.583971,
     "lbl:longitude":146.023768,
     "mps:latitude":-36.583971,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681497,
         85632793,
-        136253039,
-        85681497
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049239,
-    "wof:lastmodified":1550740364,
+    "wof:lastmodified":1560814037,
     "wof:name":"Benalla",
     "wof:parent_id":85681497,
     "wof:placetype":"county",

--- a/data/102/049/247/102049247.geojson
+++ b/data/102/049/247/102049247.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-29.593294,
     "geom:longitude":150.516814,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Gwydir Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-29.469875,
     "lbl:longitude":150.485315,
     "mps:latitude":-29.469875,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049247,
-    "wof:lastmodified":1550740558,
+    "wof:lastmodified":1560814036,
     "wof:name":"Gwydir",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/049/253/102049253.geojson
+++ b/data/102/049/253/102049253.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.954167,
     "geom:longitude":148.884829,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Yass Valley Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-34.989262,
     "lbl:longitude":148.840875,
     "mps:latitude":-34.989262,
@@ -55,9 +61,9 @@
     "wd:wordcount":1045,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102049253,
-    "wof:lastmodified":1550740610,
+    "wof:lastmodified":1560814037,
     "wof:name":"Yass Valley",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/049/261/102049261.geojson
+++ b/data/102/049/261/102049261.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.59378,
     "geom:longitude":149.742484,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Mid-Western Regional Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-32.606559,
     "lbl:longitude":149.731245,
     "mps:latitude":-32.606559,
@@ -58,9 +64,9 @@
     "wd:wordcount":324,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +84,7 @@
         }
     ],
     "wof:id":102049261,
-    "wof:lastmodified":1550740657,
+    "wof:lastmodified":1560814029,
     "wof:name":"Mid-Western Regional",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/049/275/102049275.geojson
+++ b/data/102/049/275/102049275.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-12.517976,
     "geom:longitude":142.113742,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Napranum Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-12.541342,
     "lbl:longitude":142.269087,
     "mps:latitude":-12.541342,
@@ -37,9 +43,9 @@
     "wd:wordcount":620,
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,7 +63,7 @@
         }
     ],
     "wof:id":102049275,
-    "wof:lastmodified":1550741322,
+    "wof:lastmodified":1560814029,
     "wof:name":"Napranum",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/287/102049287.geojson
+++ b/data/102/049/287/102049287.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-27.008974,
     "geom:longitude":152.425227,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Somerset Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-26.992859,
     "lbl:longitude":152.431735,
     "mps:latitude":-26.992859,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049287,
-    "wof:lastmodified":1550741384,
+    "wof:lastmodified":1560814028,
     "wof:name":"Somerset",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/303/102049303.geojson
+++ b/data/102/049/303/102049303.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-26.59274,
     "geom:longitude":152.911294,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Sunshine Coast Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-26.649174,
     "lbl:longitude":152.913424,
     "mps:latitude":-26.649174,
@@ -62,7 +68,7 @@
         }
     ],
     "wof:id":102049303,
-    "wof:lastmodified":1550741506,
+    "wof:lastmodified":1560814034,
     "wof:name":"Sunshine Coast",
     "wof:parent_id":1376953259,
     "wof:placetype":"county",

--- a/data/102/049/311/102049311.geojson
+++ b/data/102/049/311/102049311.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-40.119367,
     "geom:longitude":148.097849,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Flinders Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-40.003589,
     "lbl:longitude":148.061326,
     "mps:latitude":-40.003589,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681583,
         85632793,
-        136253039,
-        85681583
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":102049311,
-    "wof:lastmodified":1550745130,
+    "wof:lastmodified":1560814044,
     "wof:name":"Flinders",
     "wof:parent_id":85681583,
     "wof:placetype":"county",

--- a/data/102/049/343/102049343.geojson
+++ b/data/102/049/343/102049343.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-22.238145,
     "geom:longitude":147.891645,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Isaac Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-22.021869,
     "lbl:longitude":148.226881,
     "mps:latitude":-22.021869,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049343,
-    "wof:lastmodified":1550745281,
+    "wof:lastmodified":1560814047,
     "wof:name":"Isaac",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/385/102049385.geojson
+++ b/data/102/049/385/102049385.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.423221,
     "geom:longitude":149.64072,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Palerang Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-35.439902,
     "lbl:longitude":149.677529,
     "mps:latitude":-35.439902,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049385,
-    "wof:lastmodified":1550745914,
+    "wof:lastmodified":1560814031,
     "wof:name":"Palerang",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/049/391/102049391.geojson
+++ b/data/102/049/391/102049391.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-15.167084,
     "geom:longitude":145.191776,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Hope Vale Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-15.222377,
     "lbl:longitude":145.163898,
     "mps:latitude":-15.222377,
@@ -40,9 +46,9 @@
     "wd:wordcount":1829,
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -60,7 +66,7 @@
         }
     ],
     "wof:id":102049391,
-    "wof:lastmodified":1550745932,
+    "wof:lastmodified":1560814026,
     "wof:name":"Hope Vale",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/393/102049393.geojson
+++ b/data/102/049/393/102049393.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-26.147033,
     "geom:longitude":152.46357,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Gympie Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-26.165964,
     "lbl:longitude":152.414273,
     "mps:latitude":-26.165964,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049393,
-    "wof:lastmodified":1550745962,
+    "wof:lastmodified":1560814034,
     "wof:name":"Gympie",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/413/102049413.geojson
+++ b/data/102/049/413/102049413.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-29.645014,
     "geom:longitude":151.903051,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Glen Innes Severn Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-29.714291,
     "lbl:longitude":151.903241,
     "mps:latitude":-29.714291,
@@ -55,9 +61,9 @@
     "wd:wordcount":674,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102049413,
-    "wof:lastmodified":1550746182,
+    "wof:lastmodified":1560814028,
     "wof:name":"Glen Innes Severn",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/049/435/102049435.geojson
+++ b/data/102/049/435/102049435.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-25.527967,
     "geom:longitude":152.676814,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Fraser Coast Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":-25.608693,
     "lbl:longitude":152.539495,
     "mps:latitude":-25.608693,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049435,
-    "wof:lastmodified":1550746974,
+    "wof:lastmodified":1560814039,
     "wof:name":"Fraser Coast",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/445/102049445.geojson
+++ b/data/102/049/445/102049445.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.446988,
     "geom:longitude":148.355242,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Tumut Shire Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-35.424084,
     "lbl:longitude":148.348142,
     "mps:latitude":-35.424084,
@@ -55,9 +61,9 @@
     "wd:wordcount":384,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102049445,
-    "wof:lastmodified":1550747042,
+    "wof:lastmodified":1560814036,
     "wof:name":"Tumut Shire",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/049/455/102049455.geojson
+++ b/data/102/049/455/102049455.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.200396,
     "geom:longitude":146.206853,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Mansfield Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-37.189273,
     "lbl:longitude":146.217654,
     "mps:latitude":-37.189273,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681497,
         85632793,
-        136253039,
-        85681497
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049455,
-    "wof:lastmodified":1550747160,
+    "wof:lastmodified":1560814030,
     "wof:name":"Mansfield",
     "wof:parent_id":85681497,
     "wof:placetype":"county",

--- a/data/102/049/499/102049499.geojson
+++ b/data/102/049/499/102049499.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-12.441232,
     "geom:longitude":130.749695,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Wagait Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-12.434128,
     "lbl:longitude":130.741752,
     "mps:latitude":-12.434128,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681533,
         85632793,
-        136253039,
-        85681533
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049499,
-    "wof:lastmodified":1550747539,
+    "wof:lastmodified":1560814030,
     "wof:name":"Wagait",
     "wof:parent_id":85681533,
     "wof:placetype":"county",

--- a/data/102/049/511/102049511.geojson
+++ b/data/102/049/511/102049511.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.075139,
     "geom:longitude":151.051022,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Sutherland Shire Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-34.08002,
     "lbl:longitude":150.999438,
     "mps:latitude":-34.08002,
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":102049511,
-    "wof:lastmodified":1550747654,
+    "wof:lastmodified":1560814032,
     "wof:name":"Sutherland Shire",
     "wof:parent_id":1376953385,
     "wof:placetype":"county",

--- a/data/102/049/517/102049517.geojson
+++ b/data/102/049/517/102049517.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.950505,
     "geom:longitude":140.020095,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Karoonda East Murray Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-34.950038,
     "lbl:longitude":140.020136,
     "mps:latitude":-34.950038,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681519,
         85632793,
-        136253039,
-        85681519
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049517,
-    "wof:lastmodified":1550747660,
+    "wof:lastmodified":1560814031,
     "wof:name":"Karoonda East Murray",
     "wof:parent_id":85681519,
     "wof:placetype":"county",

--- a/data/102/049/549/102049549.geojson
+++ b/data/102/049/549/102049549.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-13.005308,
     "geom:longitude":143.240569,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Lockhart River Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-13.003173,
     "lbl:longitude":143.245168,
     "mps:latitude":-13.003173,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681463,
         85632793,
-        136253039,
-        85681463
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049549,
-    "wof:lastmodified":1550749590,
+    "wof:lastmodified":1560814040,
     "wof:name":"Lockhart River",
     "wof:parent_id":85681463,
     "wof:placetype":"county",

--- a/data/102/049/559/102049559.geojson
+++ b/data/102/049/559/102049559.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.462727,
     "geom:longitude":149.405384,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Warrumbungle Shire Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-31.462736,
     "lbl:longitude":149.469736,
     "mps:latitude":-31.462736,
@@ -55,9 +61,9 @@
     "wd:wordcount":282,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102049559,
-    "wof:lastmodified":1550749675,
+    "wof:lastmodified":1560814026,
     "wof:name":"Warrumbungle Shire",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/102/049/585/102049585.geojson
+++ b/data/102/049/585/102049585.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.894336,
     "geom:longitude":146.919368,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Wellington Shire"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "shire"
+    ],
     "lbl:latitude":-37.874909,
     "lbl:longitude":146.932692,
     "mps:latitude":-37.874909,
@@ -67,9 +73,9 @@
     "wd:wordcount":791,
     "wof:belongsto":[
         102191583,
+        85681497,
         85632793,
-        136253039,
-        85681497
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -87,7 +93,7 @@
         }
     ],
     "wof:id":102049585,
-    "wof:lastmodified":1550750138,
+    "wof:lastmodified":1560814041,
     "wof:name":"Wellington",
     "wof:parent_id":85681497,
     "wof:placetype":"county",

--- a/data/102/049/597/102049597.geojson
+++ b/data/102/049/597/102049597.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-27.07733,
     "geom:longitude":131.205328,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Anangu Pitjantjatjara Aboriginal Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "aboriginal council"
+    ],
     "lbl:latitude":-27.057745,
     "lbl:longitude":131.172771,
     "mps:latitude":-27.057745,
@@ -36,9 +42,9 @@
     "src:lbl:centroid":"mapshaper",
     "wof:belongsto":[
         102191583,
+        85681519,
         85632793,
-        136253039,
-        85681519
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -54,7 +60,7 @@
         }
     ],
     "wof:id":102049597,
-    "wof:lastmodified":1550750232,
+    "wof:lastmodified":1560814034,
     "wof:name":"Anangu Pitjantjatjara",
     "wof:parent_id":85681519,
     "wof:placetype":"county",

--- a/data/102/049/621/102049621.geojson
+++ b/data/102/049/621/102049621.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.941407,
     "geom:longitude":138.543861,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "City of West Torrens"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "city"
+    ],
     "lbl:latitude":-34.943019,
     "lbl:longitude":138.547105,
     "mps:latitude":-34.943019,
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":102049621,
-    "wof:lastmodified":1550751356,
+    "wof:lastmodified":1560814028,
     "wof:name":"West Torrens",
     "wof:parent_id":1376953367,
     "wof:placetype":"county",

--- a/data/102/049/625/102049625.geojson
+++ b/data/102/049/625/102049625.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.750295,
     "geom:longitude":147.171814,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Greater Hume Shire Council"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "council"
+    ],
     "lbl:latitude":-35.746058,
     "lbl:longitude":147.185076,
     "mps:latitude":-35.746058,
@@ -55,9 +61,9 @@
     "wd:wordcount":417,
     "wof:belongsto":[
         102191583,
+        85681545,
         85632793,
-        136253039,
-        85681545
+        136253039
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":102049625,
-    "wof:lastmodified":1550751372,
+    "wof:lastmodified":1560814035,
     "wof:name":"Greater Hume Shire",
     "wof:parent_id":85681545,
     "wof:placetype":"county",

--- a/data/137/695/323/9/1376953239.geojson
+++ b/data/137/695/323/9/1376953239.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.420285,
     "geom:longitude":150.850004,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Wollongong Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-34.428377,
     "lbl:longitude":150.893892,
     "mps:latitude":-34.438054,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550720426,
+    "wof:lastmodified":1560811384,
     "wof:name":"Wollongong",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/324/1/1376953241.geojson
+++ b/data/137/695/324/1/1376953241.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-23.535494,
     "geom:longitude":148.162556,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Emerald Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-23.521647,
     "lbl:longitude":148.157506,
     "mps:latitude":-23.550744,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550720436,
+    "wof:lastmodified":1560811378,
     "wof:name":"Emerald",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/324/3/1376953243.geojson
+++ b/data/137/695/324/3/1376953243.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-42.824424,
     "geom:longitude":147.381647,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Hobart Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-42.882256,
     "lbl:longitude":147.325986,
     "mps:latitude":-42.759291,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550721611,
+    "wof:lastmodified":1560811379,
     "wof:name":"Hobart",
     "wof:parent_id":85681583,
     "wof:placetype":"macrocounty",

--- a/data/137/695/324/7/1376953247.geojson
+++ b/data/137/695/324/7/1376953247.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-28.732095,
     "geom:longitude":114.650884,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Geraldton Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-28.778088,
     "lbl:longitude":114.61619,
     "mps:latitude":-28.732575,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550721660,
+    "wof:lastmodified":1560811378,
     "wof:name":"Geraldton",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/324/9/1376953249.geojson
+++ b/data/137/695/324/9/1376953249.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.713907,
     "geom:longitude":135.810744,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Port Lincoln Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-34.730421,
     "lbl:longitude":135.845127,
     "mps:latitude":-34.725451,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550721706,
+    "wof:lastmodified":1560811377,
     "wof:name":"Port Lincoln",
     "wof:parent_id":85681519,
     "wof:placetype":"macrocounty",

--- a/data/137/695/325/1/1376953251.geojson
+++ b/data/137/695/325/1/1376953251.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.362188,
     "geom:longitude":143.511784,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Swan Hill Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.341733,
     "lbl:longitude":143.543603,
     "mps:latitude":-35.364445,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550721719,
+    "wof:lastmodified":1560811388,
     "wof:name":"Swan Hill",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/325/5/1376953255.geojson
+++ b/data/137/695/325/5/1376953255.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.603945,
     "geom:longitude":149.601139,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Mudgee Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-32.602195,
     "lbl:longitude":149.572904,
     "mps:latitude":-32.598978,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550721739,
+    "wof:lastmodified":1560811388,
     "wof:name":"Mudgee",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/325/7/1376953257.geojson
+++ b/data/137/695/325/7/1376953257.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-29.677215,
     "geom:longitude":152.935448,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Grafton Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-29.683335,
     "lbl:longitude":152.935695,
     "mps:latitude":-29.675768,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550721750,
+    "wof:lastmodified":1560811388,
     "wof:name":"Grafton",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/325/9/1376953259.geojson
+++ b/data/137/695/325/9/1376953259.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-26.465991,
     "geom:longitude":152.976913,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Sunshine Coast Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-26.633507,
     "lbl:longitude":153.089756,
     "mps:latitude":-26.348242,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550721979,
+    "wof:lastmodified":1560811387,
     "wof:name":"Sunshine Coast",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/326/1/1376953261.geojson
+++ b/data/137/695/326/1/1376953261.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.61863,
     "geom:longitude":152.69327,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Camden Haven Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-31.644666,
     "lbl:longitude":152.795858,
     "mps:latitude":-31.618958,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722004,
+    "wof:lastmodified":1560811415,
     "wof:name":"Camden Haven",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/326/5/1376953265.geojson
+++ b/data/137/695/326/5/1376953265.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-38.358835,
     "geom:longitude":143.578547,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Colac Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-38.341175,
     "lbl:longitude":143.585664,
     "mps:latitude":-38.365132,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722011,
+    "wof:lastmodified":1560811416,
     "wof:name":"Colac",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/326/7/1376953267.geojson
+++ b/data/137/695/326/7/1376953267.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.575229,
     "geom:longitude":151.177284,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Singleton Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-32.566463,
     "lbl:longitude":151.176038,
     "mps:latitude":-32.576272,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722046,
+    "wof:lastmodified":1560811415,
     "wof:name":"Singleton",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/326/9/1376953269.geojson
+++ b/data/137/695/326/9/1376953269.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-38.199213,
     "geom:longitude":146.527923,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Traralgon - Morwell Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-38.196566,
     "lbl:longitude":146.533757,
     "mps:latitude":-38.205237,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550718485,
+    "wof:lastmodified":1560811414,
     "wof:name":"Traralgon - Morwell",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/327/1/1376953271.geojson
+++ b/data/137/695/327/1/1376953271.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.123272,
     "geom:longitude":147.366774,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Wagga Wagga Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.108503,
     "lbl:longitude":147.359497,
     "mps:latitude":-35.13781,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722055,
+    "wof:lastmodified":1560811397,
     "wof:name":"Wagga Wagga",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/327/3/1376953273.geojson
+++ b/data/137/695/327/3/1376953273.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-23.923585,
     "geom:longitude":151.303787,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Gladstone - Tannum Sands Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-23.841229,
     "lbl:longitude":151.253107,
     "mps:latitude":-23.903573,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550718596,
+    "wof:lastmodified":1560811397,
     "wof:name":"Gladstone - Tannum Sands",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/327/5/1376953275.geojson
+++ b/data/137/695/327/5/1376953275.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-41.26679,
     "geom:longitude":146.459316,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Devonport Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-41.176596,
     "lbl:longitude":146.345469,
     "mps:latitude":-41.297936,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722512,
+    "wof:lastmodified":1560811398,
     "wof:name":"Devonport",
     "wof:parent_id":85681583,
     "wof:placetype":"macrocounty",

--- a/data/137/695/327/7/1376953277.geojson
+++ b/data/137/695/327/7/1376953277.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-30.75791,
     "geom:longitude":121.465345,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Kalgoorlie - Boulder Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-30.752372,
     "lbl:longitude":121.469366,
     "mps:latitude":-30.748622,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550718602,
+    "wof:lastmodified":1560811397,
     "wof:name":"Kalgoorlie - Boulder",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/327/9/1376953279.geojson
+++ b/data/137/695/327/9/1376953279.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.497916,
     "geom:longitude":137.80116,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Port Augusta Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-32.496808,
     "lbl:longitude":137.792071,
     "mps:latitude":-32.514061,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722520,
+    "wof:lastmodified":1560811397,
     "wof:name":"Port Augusta",
     "wof:parent_id":85681519,
     "wof:placetype":"macrocounty",

--- a/data/137/695/328/3/1376953283.geojson
+++ b/data/137/695/328/3/1376953283.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.828372,
     "geom:longitude":145.149039,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Melbourne Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-37.825071,
     "lbl:longitude":144.978682,
     "mps:latitude":-37.918556,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722776,
+    "wof:lastmodified":1560811411,
     "wof:name":"Melbourne",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/328/5/1376953285.geojson
+++ b/data/137/695/328/5/1376953285.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-23.348549,
     "geom:longitude":150.473223,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Rockhampton Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-23.379739,
     "lbl:longitude":150.509755,
     "mps:latitude":-23.269053,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722810,
+    "wof:lastmodified":1560811414,
     "wof:name":"Rockhampton",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/328/7/1376953287.geojson
+++ b/data/137/695/328/7/1376953287.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.054761,
     "geom:longitude":146.955859,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Albury Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-36.074771,
     "lbl:longitude":146.914504,
     "mps:latitude":-36.12061,
@@ -50,7 +56,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550718640,
+    "wof:lastmodified":1560811410,
     "wof:name":"Albury",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/328/9/1376953289.geojson
+++ b/data/137/695/328/9/1376953289.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.314082,
     "geom:longitude":150.908255,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Muswellbrook Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-32.27371,
     "lbl:longitude":150.896582,
     "mps:latitude":-32.341764,
@@ -49,7 +55,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550752509,
+    "wof:lastmodified":1560811409,
     "wof:name":"Muswellbrook",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/329/1/1376953291.geojson
+++ b/data/137/695/329/1/1376953291.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.29885,
     "geom:longitude":149.127306,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Canberra Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.280901,
     "lbl:longitude":149.129269,
     "mps:latitude":-35.31778,
@@ -50,7 +56,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550752565,
+    "wof:lastmodified":1560811402,
     "wof:name":"Canberra",
     "wof:parent_id":85681493,
     "wof:placetype":"macrocounty",

--- a/data/137/695/329/3/1376953293.geojson
+++ b/data/137/695/329/3/1376953293.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-28.8205,
     "geom:longitude":153.299052,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Lismore Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-28.810195,
     "lbl:longitude":153.289347,
     "mps:latitude":-28.816531,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722865,
+    "wof:lastmodified":1560811403,
     "wof:name":"Lismore",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/329/5/1376953295.geojson
+++ b/data/137/695/329/5/1376953295.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.343333,
     "geom:longitude":150.451153,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Ulladulla Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.35646,
     "lbl:longitude":150.461595,
     "mps:latitude":-35.329745,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550722879,
+    "wof:lastmodified":1560811403,
     "wof:name":"Ulladulla",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/329/7/1376953297.geojson
+++ b/data/137/695/329/7/1376953297.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.347444,
     "geom:longitude":151.411242,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Central Coast Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.427354,
     "lbl:longitude":151.342636,
     "mps:latitude":-33.382614,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723024,
+    "wof:lastmodified":1560811400,
     "wof:name":"Central Coast",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/330/1/1376953301.geojson
+++ b/data/137/695/330/1/1376953301.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.745862,
     "geom:longitude":144.288926,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Bendigo Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-36.757608,
     "lbl:longitude":144.27957,
     "mps:latitude":-36.755279,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723050,
+    "wof:lastmodified":1560811368,
     "wof:name":"Bendigo",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/330/3/1376953303.geojson
+++ b/data/137/695/330/3/1376953303.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.092701,
     "geom:longitude":150.627962,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "St Georges Basin - Sanctuary Point Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.09403,
     "lbl:longitude":150.600362,
     "mps:latitude":-35.109247,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550718655,
+    "wof:lastmodified":1560811368,
     "wof:name":"St Georges Basin - Sanctuary Point",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/330/5/1376953305.geojson
+++ b/data/137/695/330/5/1376953305.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.358904,
     "geom:longitude":146.309652,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Wangaratta Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-36.363389,
     "lbl:longitude":146.314859,
     "mps:latitude":-36.358128,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723069,
+    "wof:lastmodified":1560811368,
     "wof:name":"Wangaratta",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/330/7/1376953307.geojson
+++ b/data/137/695/330/7/1376953307.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-27.945,
     "geom:longitude":153.334282,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Gold Coast Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-28.017366,
     "lbl:longitude":153.42725,
     "mps:latitude":-28.175738,
@@ -50,7 +56,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550718897,
+    "wof:lastmodified":1560811367,
     "wof:name":"Gold Coast",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/330/9/1376953309.geojson
+++ b/data/137/695/330/9/1376953309.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-41.0407,
     "geom:longitude":145.798228,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Burnie - Wynyard Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-41.053415,
     "lbl:longitude":145.905099,
     "mps:latitude":-41.045603,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719062,
+    "wof:lastmodified":1560811366,
     "wof:name":"Burnie - Wynyard",
     "wof:parent_id":85681583,
     "wof:placetype":"macrocounty",

--- a/data/137/695/331/1/1376953311.geojson
+++ b/data/137/695/331/1/1376953311.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.720617,
     "geom:longitude":115.345658,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Busselton Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.655377,
     "lbl:longitude":115.350089,
     "mps:latitude":-33.737315,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723090,
+    "wof:lastmodified":1560811364,
     "wof:name":"Busselton",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/331/3/1376953313.geojson
+++ b/data/137/695/331/3/1376953313.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.522374,
     "geom:longitude":138.712079,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Victor Harbor - Goolwa Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.550015,
     "lbl:longitude":138.612357,
     "mps:latitude":-35.492799,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719071,
+    "wof:lastmodified":1560811365,
     "wof:name":"Victor Harbor - Goolwa",
     "wof:parent_id":85681519,
     "wof:placetype":"macrocounty",

--- a/data/137/695/331/5/1376953315.geojson
+++ b/data/137/695/331/5/1376953315.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.675004,
     "geom:longitude":144.569845,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Melton Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-37.684986,
     "lbl:longitude":144.588885,
     "mps:latitude":-37.677522,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723228,
+    "wof:lastmodified":1560811365,
     "wof:name":"Melton",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/331/9/1376953319.geojson
+++ b/data/137/695/331/9/1376953319.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-20.725833,
     "geom:longitude":139.510289,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Mount Isa Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-20.724817,
     "lbl:longitude":139.493272,
     "mps:latitude":-20.741348,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723235,
+    "wof:lastmodified":1560811364,
     "wof:name":"Mount Isa",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/332/1/1376953321.geojson
+++ b/data/137/695/332/1/1376953321.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.442766,
     "geom:longitude":150.448194,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Bowral - Mittagong Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-34.474442,
     "lbl:longitude":150.416315,
     "mps:latitude":-34.451209,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719100,
+    "wof:lastmodified":1560811390,
     "wof:name":"Bowral - Mittagong",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/332/3/1376953323.geojson
+++ b/data/137/695/332/3/1376953323.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.553974,
     "geom:longitude":143.836709,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Ballarat Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-37.563892,
     "lbl:longitude":143.852395,
     "mps:latitude":-37.551891,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723255,
+    "wof:lastmodified":1560811390,
     "wof:name":"Ballarat",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/332/5/1376953325.geojson
+++ b/data/137/695/332/5/1376953325.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.758385,
     "geom:longitude":152.07539,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Nelson Bay Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-32.744119,
     "lbl:longitude":152.193316,
     "mps:latitude":-32.757482,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723423,
+    "wof:lastmodified":1560811391,
     "wof:name":"Nelson Bay",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/332/7/1376953327.geojson
+++ b/data/137/695/332/7/1376953327.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.081446,
     "geom:longitude":152.82857,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Kempsey Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-31.076544,
     "lbl:longitude":152.839218,
     "mps:latitude":-31.085116,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723644,
+    "wof:lastmodified":1560811389,
     "wof:name":"Kempsey",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/332/9/1376953329.geojson
+++ b/data/137/695/332/9/1376953329.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.892449,
     "geom:longitude":152.430303,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Taree Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-31.877858,
     "lbl:longitude":152.438906,
     "mps:latitude":-31.87671,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723666,
+    "wof:lastmodified":1560811389,
     "wof:name":"Taree",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/333/1/1376953331.geojson
+++ b/data/137/695/333/1/1376953331.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-26.192302,
     "geom:longitude":152.663306,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Gympie Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-26.182873,
     "lbl:longitude":152.665451,
     "mps:latitude":-26.19395,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723725,
+    "wof:lastmodified":1560811397,
     "wof:name":"Gympie",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/333/3/1376953333.geojson
+++ b/data/137/695/333/3/1376953333.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.244604,
     "geom:longitude":148.630719,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Dubbo Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-32.250776,
     "lbl:longitude":148.615532,
     "mps:latitude":-32.23962,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723758,
+    "wof:lastmodified":1560811397,
     "wof:name":"Dubbo",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/333/7/1376953337.geojson
+++ b/data/137/695/333/7/1376953337.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.799746,
     "geom:longitude":121.854764,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Esperance Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.860243,
     "lbl:longitude":121.888248,
     "mps:latitude":-33.800093,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723772,
+    "wof:lastmodified":1560811396,
     "wof:name":"Esperance",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/333/9/1376953339.geojson
+++ b/data/137/695/333/9/1376953339.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.188646,
     "geom:longitude":138.003294,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Port Pirie Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.168114,
     "lbl:longitude":138.008955,
     "mps:latitude":-33.202605,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723776,
+    "wof:lastmodified":1560811396,
     "wof:name":"Port Pirie",
     "wof:parent_id":85681519,
     "wof:placetype":"macrocounty",

--- a/data/137/695/334/1/1376953341.geojson
+++ b/data/137/695/334/1/1376953341.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.208897,
     "geom:longitude":142.109971,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Mildura Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-34.199704,
     "lbl:longitude":142.153732,
     "mps:latitude":-34.141785,
@@ -50,7 +56,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719226,
+    "wof:lastmodified":1560811396,
     "wof:name":"Mildura",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/334/3/1376953343.geojson
+++ b/data/137/695/334/3/1376953343.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-25.539383,
     "geom:longitude":152.684694,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Maryborough Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-25.527814,
     "lbl:longitude":152.693741,
     "mps:latitude":-25.531306,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723867,
+    "wof:lastmodified":1560811396,
     "wof:name":"Maryborough",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/334/5/1376953345.geojson
+++ b/data/137/695/334/5/1376953345.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.944036,
     "geom:longitude":141.479268,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Broken Hill Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-31.958,
     "lbl:longitude":141.459866,
     "mps:latitude":-31.942362,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723873,
+    "wof:lastmodified":1560811396,
     "wof:name":"Broken Hill",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/334/7/1376953347.geojson
+++ b/data/137/695/334/7/1376953347.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.829164,
     "geom:longitude":147.613984,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Bairnsdale Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-37.833065,
     "lbl:longitude":147.614768,
     "mps:latitude":-37.822571,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723884,
+    "wof:lastmodified":1560811396,
     "wof:name":"Bairnsdale",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/334/9/1376953349.geojson
+++ b/data/137/695/334/9/1376953349.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.833407,
     "geom:longitude":151.597611,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Newcastle - Maitland Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-32.9278,
     "lbl:longitude":151.782607,
     "mps:latitude":-32.70838,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719468,
+    "wof:lastmodified":1560811393,
     "wof:name":"Newcastle - Maitland",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/335/1/1376953351.geojson
+++ b/data/137/695/335/1/1376953351.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.083514,
     "geom:longitude":151.456031,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Morisset - Cooranbong Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.104521,
     "lbl:longitude":151.488455,
     "mps:latitude":-33.066822,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719504,
+    "wof:lastmodified":1560811392,
     "wof:name":"Morisset - Cooranbong",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/335/5/1376953355.geojson
+++ b/data/137/695/335/5/1376953355.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.118748,
     "geom:longitude":150.932637,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Tamworth Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-31.092751,
     "lbl:longitude":150.931684,
     "mps:latitude":-31.137731,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723892,
+    "wof:lastmodified":1560811393,
     "wof:name":"Tamworth",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/335/7/1376953357.geojson
+++ b/data/137/695/335/7/1376953357.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-38.374423,
     "geom:longitude":142.547432,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Warrnambool Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-38.3777,
     "lbl:longitude":142.480446,
     "mps:latitude":-38.387178,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723900,
+    "wof:lastmodified":1560811392,
     "wof:name":"Warrnambool",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/335/9/1376953359.geojson
+++ b/data/137/695/335/9/1376953359.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-23.154804,
     "geom:longitude":150.737495,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Yeppoon Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-23.129481,
     "lbl:longitude":150.738213,
     "mps:latitude":-23.15454,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550723931,
+    "wof:lastmodified":1560811392,
     "wof:name":"Yeppoon",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/336/1/1376953361.geojson
+++ b/data/137/695/336/1/1376953361.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.869101,
     "geom:longitude":150.587083,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Nowra - Bomaderry Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-34.884583,
     "lbl:longitude":150.60242,
     "mps:latitude":-34.869389,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719602,
+    "wof:lastmodified":1560811363,
     "wof:name":"Nowra - Bomaderry",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/336/3/1376953363.geojson
+++ b/data/137/695/336/3/1376953363.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-30.16188,
     "geom:longitude":153.125559,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Coffs Harbour Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-30.290583,
     "lbl:longitude":153.114278,
     "mps:latitude":-30.055222,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550724056,
+    "wof:lastmodified":1560811363,
     "wof:name":"Coffs Harbour",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/336/5/1376953365.geojson
+++ b/data/137/695/336/5/1376953365.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-17.94472,
     "geom:longitude":122.222987,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Broome Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-17.962931,
     "lbl:longitude":122.231319,
     "mps:latitude":-17.944562,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550724061,
+    "wof:lastmodified":1560811364,
     "wof:name":"Broome",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/336/7/1376953367.geojson
+++ b/data/137/695/336/7/1376953367.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.908828,
     "geom:longitude":138.659768,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Adelaide Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-34.929075,
     "lbl:longitude":138.602578,
     "mps:latitude":-34.915689,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550724258,
+    "wof:lastmodified":1560811362,
     "wof:name":"Adelaide",
     "wof:parent_id":85681519,
     "wof:placetype":"macrocounty",

--- a/data/137/695/337/3/1376953373.geojson
+++ b/data/137/695/337/3/1376953373.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-38.196613,
     "geom:longitude":146.295916,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Moe - Newborough Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-38.175413,
     "lbl:longitude":146.253707,
     "mps:latitude":-38.194211,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719615,
+    "wof:lastmodified":1560811370,
     "wof:name":"Moe - Newborough",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/337/5/1376953375.geojson
+++ b/data/137/695/337/5/1376953375.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-21.118781,
     "geom:longitude":149.160516,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Mackay Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-21.144192,
     "lbl:longitude":149.182075,
     "mps:latitude":-21.089116,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550724301,
+    "wof:lastmodified":1560811370,
     "wof:name":"Mackay",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/337/7/1376953377.geojson
+++ b/data/137/695/337/7/1376953377.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.728028,
     "geom:longitude":150.191101,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Batemans Bay Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.709068,
     "lbl:longitude":150.176583,
     "mps:latitude":-35.728122,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550724525,
+    "wof:lastmodified":1560811369,
     "wof:name":"Batemans Bay",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/337/9/1376953379.geojson
+++ b/data/137/695/337/9/1376953379.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-25.291676,
     "geom:longitude":152.812975,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Hervey Bay Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-25.2833,
     "lbl:longitude":152.8333,
     "mps:latitude":-25.280796,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550724627,
+    "wof:lastmodified":1560811368,
     "wof:name":"Hervey Bay",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/338/1/1376953381.geojson
+++ b/data/137/695/338/1/1376953381.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.637945,
     "geom:longitude":144.454615,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Bacchus Marsh Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-37.672259,
     "lbl:longitude":144.431034,
     "mps:latitude":-37.6405,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550724681,
+    "wof:lastmodified":1560811351,
     "wof:name":"Bacchus Marsh",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/338/3/1376953383.geojson
+++ b/data/137/695/338/3/1376953383.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.478646,
     "geom:longitude":150.124773,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Lithgow Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.485129,
     "lbl:longitude":150.15933,
     "mps:latitude":-33.476987,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550724690,
+    "wof:lastmodified":1560811351,
     "wof:name":"Lithgow",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/338/5/1376953385.geojson
+++ b/data/137/695/338/5/1376953385.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.764281,
     "geom:longitude":150.909497,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Sydney Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.868633,
     "lbl:longitude":151.209421,
     "mps:latitude":-33.732117,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726294,
+    "wof:lastmodified":1560811353,
     "wof:name":"Sydney",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/338/7/1376953387.geojson
+++ b/data/137/695/338/7/1376953387.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-23.735073,
     "geom:longitude":133.854769,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Alice Springs Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-23.698651,
     "lbl:longitude":133.882345,
     "mps:latitude":-23.730835,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726305,
+    "wof:lastmodified":1560811350,
     "wof:name":"Alice Springs",
     "wof:parent_id":85681533,
     "wof:placetype":"macrocounty",

--- a/data/137/695/339/1/1376953391.geojson
+++ b/data/137/695/339/1/1376953391.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.731762,
     "geom:longitude":142.214494,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Horsham Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-36.718918,
     "lbl:longitude":142.196233,
     "mps:latitude":-36.73273,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726316,
+    "wof:lastmodified":1560811374,
     "wof:name":"Horsham",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/339/3/1376953393.geojson
+++ b/data/137/695/339/3/1376953393.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-38.340253,
     "geom:longitude":141.584123,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Portland Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-38.371829,
     "lbl:longitude":141.605307,
     "mps:latitude":-38.335912,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726322,
+    "wof:lastmodified":1560811374,
     "wof:name":"Portland",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/339/5/1376953395.geojson
+++ b/data/137/695/339/5/1376953395.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-38.176224,
     "geom:longitude":145.873434,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Warragul - Drouin Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-38.161766,
     "lbl:longitude":145.934879,
     "mps:latitude":-38.191502,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719630,
+    "wof:lastmodified":1560811374,
     "wof:name":"Warragul - Drouin",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/339/7/1376953397.geojson
+++ b/data/137/695/339/7/1376953397.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-27.478221,
     "geom:longitude":152.970711,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Brisbane Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-27.469309,
     "lbl:longitude":153.026164,
     "mps:latitude":-27.698292,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726643,
+    "wof:lastmodified":1560811371,
     "wof:name":"Brisbane",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/339/9/1376953399.geojson
+++ b/data/137/695/339/9/1376953399.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.265644,
     "geom:longitude":149.121731,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Orange Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.284306,
     "lbl:longitude":149.0986,
     "mps:latitude":-33.270123,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726675,
+    "wof:lastmodified":1560811370,
     "wof:name":"Orange",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/340/1/1376953401.geojson
+++ b/data/137/695/340/1/1376953401.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.503357,
     "geom:longitude":115.624398,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Yanchep Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-31.537346,
     "lbl:longitude":115.640515,
     "mps:latitude":-31.489182,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726691,
+    "wof:lastmodified":1560811386,
     "wof:name":"Yanchep",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/340/3/1376953403.geojson
+++ b/data/137/695/340/3/1376953403.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.750592,
     "geom:longitude":149.719573,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Goulburn Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-34.747283,
     "lbl:longitude":149.726961,
     "mps:latitude":-34.747273,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726721,
+    "wof:lastmodified":1560811386,
     "wof:name":"Goulburn",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/340/5/1376953405.geojson
+++ b/data/137/695/340/5/1376953405.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.35584,
     "geom:longitude":115.66285,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Bunbury Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.327283,
     "lbl:longitude":115.638324,
     "mps:latitude":-33.355224,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726738,
+    "wof:lastmodified":1560811386,
     "wof:name":"Bunbury",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/340/9/1376953409.geojson
+++ b/data/137/695/340/9/1376953409.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-28.232474,
     "geom:longitude":152.005973,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Warwick Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-28.216157,
     "lbl:longitude":152.027697,
     "mps:latitude":-28.225501,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726753,
+    "wof:lastmodified":1560811386,
     "wof:name":"Warwick",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/341/1/1376953411.geojson
+++ b/data/137/695/341/1/1376953411.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.406233,
     "geom:longitude":149.589876,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Bathurst Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.417961,
     "lbl:longitude":149.576458,
     "mps:latitude":-33.406815,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726810,
+    "wof:lastmodified":1560811377,
     "wof:name":"Bathurst",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/341/3/1376953413.geojson
+++ b/data/137/695/341/3/1376953413.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-26.531858,
     "geom:longitude":151.840896,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Kingaroy Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-26.537388,
     "lbl:longitude":151.841133,
     "mps:latitude":-26.542443,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726815,
+    "wof:lastmodified":1560811377,
     "wof:name":"Kingaroy",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/341/5/1376953415.geojson
+++ b/data/137/695/341/5/1376953415.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-12.467325,
     "geom:longitude":130.974935,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Darwin Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-12.460477,
     "lbl:longitude":130.842984,
     "mps:latitude":-12.486787,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726833,
+    "wof:lastmodified":1560811377,
     "wof:name":"Darwin",
     "wof:parent_id":85681533,
     "wof:placetype":"macrocounty",

--- a/data/137/695/341/7/1376953417.geojson
+++ b/data/137/695/341/7/1376953417.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.041405,
     "geom:longitude":137.536518,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Whyalla Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.036167,
     "lbl:longitude":137.573457,
     "mps:latitude":-33.039584,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726838,
+    "wof:lastmodified":1560811377,
     "wof:name":"Whyalla",
     "wof:parent_id":85681519,
     "wof:placetype":"macrocounty",

--- a/data/137/695/341/9/1376953419.geojson
+++ b/data/137/695/341/9/1376953419.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-41.195265,
     "geom:longitude":146.220508,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Ulverstone Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-41.160374,
     "lbl:longitude":146.177836,
     "mps:latitude":-41.190515,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726963,
+    "wof:lastmodified":1560811375,
     "wof:name":"Ulverstone",
     "wof:parent_id":85681583,
     "wof:placetype":"macrocounty",

--- a/data/137/695/342/1/1376953421.geojson
+++ b/data/137/695/342/1/1376953421.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.465921,
     "geom:longitude":144.586566,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Gisborne - Macedon Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-37.491718,
     "lbl:longitude":144.594533,
     "mps:latitude":-37.469146,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719645,
+    "wof:lastmodified":1560811404,
     "wof:name":"Gisborne - Macedon",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/342/3/1376953423.geojson
+++ b/data/137/695/342/3/1376953423.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-20.748884,
     "geom:longitude":116.821602,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Karratha Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-20.734043,
     "lbl:longitude":116.844766,
     "mps:latitude":-20.753944,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550726975,
+    "wof:lastmodified":1560811404,
     "wof:name":"Karratha",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/342/7/1376953427.geojson
+++ b/data/137/695/342/7/1376953427.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-38.104658,
     "geom:longitude":147.056263,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Sale Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-38.103688,
     "lbl:longitude":147.063641,
     "mps:latitude":-38.09828,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550727051,
+    "wof:lastmodified":1560811404,
     "wof:name":"Sale",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/342/9/1376953429.geojson
+++ b/data/137/695/342/9/1376953429.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-30.503132,
     "geom:longitude":151.667794,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Armidale Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-30.51268,
     "lbl:longitude":151.663934,
     "mps:latitude":-30.509774,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550727195,
+    "wof:lastmodified":1560811403,
     "wof:name":"Armidale",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/343/1/1376953431.geojson
+++ b/data/137/695/343/1/1376953431.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-24.863076,
     "geom:longitude":152.373366,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Bundaberg Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-24.866966,
     "lbl:longitude":152.350375,
     "mps:latitude":-24.860437,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550727432,
+    "wof:lastmodified":1560811418,
     "wof:name":"Bundaberg",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/343/3/1376953433.geojson
+++ b/data/137/695/343/3/1376953433.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-33.172943,
     "geom:longitude":148.189852,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Parkes Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-33.139833,
     "lbl:longitude":148.179809,
     "mps:latitude":-33.168841,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550727447,
+    "wof:lastmodified":1560811418,
     "wof:name":"Parkes",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/343/5/1376953435.geojson
+++ b/data/137/695/343/5/1376953435.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-20.360751,
     "geom:longitude":118.623132,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Port Hedland Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-20.376992,
     "lbl:longitude":118.626374,
     "mps:latitude":-20.362878,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550727455,
+    "wof:lastmodified":1560811419,
     "wof:name":"Port Hedland",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/343/7/1376953437.geojson
+++ b/data/137/695/343/7/1376953437.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.202124,
     "geom:longitude":152.517312,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Forster - Tuncurry Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-32.220408,
     "lbl:longitude":152.547653,
     "mps:latitude":-32.203309,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550719867,
+    "wof:lastmodified":1560811418,
     "wof:name":"Forster - Tuncurry",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/344/1/1376953441.geojson
+++ b/data/137/695/344/1/1376953441.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.126482,
     "geom:longitude":139.257892,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Murray Bridge Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.130613,
     "lbl:longitude":139.267949,
     "mps:latitude":-35.122279,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550727459,
+    "wof:lastmodified":1560811417,
     "wof:name":"Murray Bridge",
     "wof:parent_id":85681519,
     "wof:placetype":"macrocounty",

--- a/data/137/695/344/5/1376953445.geojson
+++ b/data/137/695/344/5/1376953445.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-19.334144,
     "geom:longitude":146.721135,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Townsville Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-19.259749,
     "lbl:longitude":146.814815,
     "mps:latitude":-19.31457,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550727516,
+    "wof:lastmodified":1560811417,
     "wof:name":"Townsville",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/344/7/1376953447.geojson
+++ b/data/137/695/344/7/1376953447.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-38.09239,
     "geom:longitude":144.39167,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Geelong Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-38.150785,
     "lbl:longitude":144.361579,
     "mps:latitude":-37.959007,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550727780,
+    "wof:lastmodified":1560811416,
     "wof:name":"Geelong",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/345/1/1376953451.geojson
+++ b/data/137/695/345/1/1376953451.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-41.46267,
     "geom:longitude":147.083887,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Launceston Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-41.43951,
     "lbl:longitude":147.13763,
     "mps:latitude":-41.452958,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550727940,
+    "wof:lastmodified":1560811405,
     "wof:name":"Launceston",
     "wof:parent_id":85681583,
     "wof:placetype":"macrocounty",

--- a/data/137/695/345/3/1376953453.geojson
+++ b/data/137/695/345/3/1376953453.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-32.188824,
     "geom:longitude":115.898402,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Perth Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-31.960773,
     "lbl:longitude":115.834088,
     "mps:latitude":-32.052647,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550728067,
+    "wof:lastmodified":1560811407,
     "wof:name":"Perth",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/345/5/1376953455.geojson
+++ b/data/137/695/345/5/1376953455.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.402273,
     "geom:longitude":145.410436,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Shepparton - Mooroopna Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-36.36548,
     "lbl:longitude":145.406836,
     "mps:latitude":-36.39916,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550720045,
+    "wof:lastmodified":1560811409,
     "wof:name":"Shepparton - Mooroopna",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/695/345/7/1376953457.geojson
+++ b/data/137/695/345/7/1376953457.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-28.816654,
     "geom:longitude":153.569664,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Ballina Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-28.862692,
     "lbl:longitude":153.562116,
     "mps:latitude":-28.819529,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550728108,
+    "wof:lastmodified":1560811405,
     "wof:name":"Ballina",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/345/9/1376953459.geojson
+++ b/data/137/695/345/9/1376953459.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-16.890226,
     "geom:longitude":145.712549,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Cairns Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-16.922929,
     "lbl:longitude":145.775689,
     "mps:latitude":-16.883255,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550728140,
+    "wof:lastmodified":1560811404,
     "wof:name":"Cairns",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/346/3/1376953463.geojson
+++ b/data/137/695/346/3/1376953463.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-31.455802,
     "geom:longitude":152.877177,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Port Macquarie Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-31.463755,
     "lbl:longitude":152.898783,
     "mps:latitude":-31.458492,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550728152,
+    "wof:lastmodified":1560811375,
     "wof:name":"Port Macquarie",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/346/5/1376953465.geojson
+++ b/data/137/695/346/5/1376953465.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.281235,
     "geom:longitude":146.048467,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Griffith Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-34.286686,
     "lbl:longitude":146.04075,
     "mps:latitude":-34.282902,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550728159,
+    "wof:lastmodified":1560811375,
     "wof:name":"Griffith",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/695/346/7/1376953467.geojson
+++ b/data/137/695/346/7/1376953467.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.008129,
     "geom:longitude":117.85432,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Albany Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.031075,
     "lbl:longitude":117.89494,
     "mps:latitude":-34.966785,
@@ -49,7 +55,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550752776,
+    "wof:lastmodified":1560811374,
     "wof:name":"Albany",
     "wof:parent_id":85681439,
     "wof:placetype":"macrocounty",

--- a/data/137/695/346/9/1376953469.geojson
+++ b/data/137/695/346/9/1376953469.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.816017,
     "geom:longitude":140.756851,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Mount Gambier Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-37.826477,
     "lbl:longitude":140.775335,
     "mps:latitude":-37.816142,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550728163,
+    "wof:lastmodified":1560811374,
     "wof:name":"Mount Gambier",
     "wof:parent_id":85681519,
     "wof:placetype":"macrocounty",

--- a/data/137/695/347/1/1376953471.geojson
+++ b/data/137/695/347/1/1376953471.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-27.563108,
     "geom:longitude":151.895823,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Toowoomba Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-27.564533,
     "lbl:longitude":151.95552,
     "mps:latitude":-27.563421,
@@ -52,7 +58,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550728181,
+    "wof:lastmodified":1560811386,
     "wof:name":"Toowoomba",
     "wof:parent_id":85681463,
     "wof:placetype":"macrocounty",

--- a/data/137/695/347/3/1376953473.geojson
+++ b/data/137/695/347/3/1376953473.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.16374,
     "geom:longitude":144.772147,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Echuca Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-36.129592,
     "lbl:longitude":144.750017,
     "mps:latitude":-36.122707,
@@ -50,7 +56,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550720182,
+    "wof:lastmodified":1560811387,
     "wof:name":"Echuca",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/696/804/5/1376968045.geojson
+++ b/data/137/696/804/5/1376968045.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.366095,
     "geom:longitude":149.227749,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Queanbeyan Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-35.353399,
     "lbl:longitude":149.230104,
     "mz:hierarchy_label":1,
@@ -48,7 +54,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550753438,
+    "wof:lastmodified":1560811419,
     "wof:name":"Queanbeyan",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/696/805/1/1376968051.geojson
+++ b/data/137/696/805/1/1376968051.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.150505,
     "geom:longitude":146.882612,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Wodonga Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-36.127609,
     "lbl:longitude":146.89372,
     "mz:hierarchy_label":1,
@@ -48,7 +54,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550720203,
+    "wof:lastmodified":1560811419,
     "wof:name":"Wodonga",
     "wof:parent_id":85681497,
     "wof:placetype":"macrocounty",

--- a/data/137/696/805/3/1376968053.geojson
+++ b/data/137/696/805/3/1376968053.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-34.114144,
     "geom:longitude":142.041229,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Wentworth Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-34.105701,
     "lbl:longitude":141.915422,
     "mz:hierarchy_label":1,
@@ -48,7 +54,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550720282,
+    "wof:lastmodified":1560811420,
     "wof:name":"Wentworth",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/696/805/5/1376968055.geojson
+++ b/data/137/696/805/5/1376968055.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-28.316142,
     "geom:longitude":153.496674,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Tweed Heads Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-28.181508,
     "lbl:longitude":153.529624,
     "mz:hierarchy_label":1,
@@ -48,7 +54,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550720339,
+    "wof:lastmodified":1560811421,
     "wof:name":"Tweed Heads",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",

--- a/data/137/696/805/7/1376968057.geojson
+++ b/data/137/696/805/7/1376968057.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-36.057832,
     "geom:longitude":144.7757,
     "iso:country":"AU",
+    "label:eng_x_preferred_longname":[
+        "Moama Urban Area"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "significant urban area"
+    ],
     "lbl:latitude":-36.107768,
     "lbl:longitude":144.762281,
     "mz:hierarchy_label":1,
@@ -48,7 +54,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1550720362,
+    "wof:lastmodified":1560811419,
     "wof:name":"Moama",
     "wof:parent_id":85681545,
     "wof:placetype":"macrocounty",


### PR DESCRIPTION
Fixes the Australian portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1640.

- [x] Regions (completed in previous commits)
- [x] Macrocounties
  - "Significant Urban Areas", though the longname ditches "Significant" in preference of "name + Urban Area"
- [x] Counties
  - Mix of shire, region, council, etc
  - Most were completed through a previous commit