### PR TITLE
Update properties of megacities

### DIFF
--- a/data/101/932/003/101932003.geojson
+++ b/data/101/932/003/101932003.geojson
@@ -19,7 +19,7 @@
     "mps:longitude":151.209421,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
-    "mz:min_zoom":4.0,
+    "mz:min_zoom":1.7,
     "name:abk_x_preferred":[
         "\u0421\u0438\u0434\u043d\u0435\u0438"
     ],
@@ -670,6 +670,7 @@
         "gn:id":2147714,
         "gp:id":1105779,
         "loc:id":"n79021855",
+        "ne:id":1159151623,
         "nyt:id":"43567305142726089371",
         "qs_pg:id":351657,
         "wd:id":"Q3130",
@@ -702,7 +703,8 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1607462638,
+    "wof:lastmodified":1608688194,
+    "wof:megacity":1,
     "wof:name":"Sydney",
     "wof:parent_id":404226357,
     "wof:placetype":"locality",

--- a/data/101/933/229/101933229.geojson
+++ b/data/101/933/229/101933229.geojson
@@ -655,6 +655,7 @@
         "gn:id":2158177,
         "gp:id":1103816,
         "loc:id":"n79029787",
+        "ne:id":1159151565,
         "nyt:id":9223372036854775807,
         "qs_pg:id":1062623,
         "wd:id":"Q3141",
@@ -684,7 +685,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1607462622,
+    "wof:lastmodified":1608688191,
     "wof:megacity":1,
     "wof:name":"Melbourne",
     "wof:parent_id":404539427,

--- a/data/101/934/019/101934019.geojson
+++ b/data/101/934/019/101934019.geojson
@@ -18,7 +18,7 @@
     "mps:latitude":-27.469309,
     "mps:longitude":153.026164,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":4.0,
     "name:afr_x_preferred":[
         "Brisbane"
@@ -622,6 +622,7 @@
         "fct:id":"033eac88-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2174003,
         "gp:id":1100661,
+        "ne:id":1159151169,
         "nyt:id":"N4276473884076253791",
         "qs_pg:id":807997,
         "wd:id":"Q34932",
@@ -648,7 +649,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1607462612,
+    "wof:lastmodified":1608688179,
     "wof:megacity":1,
     "wof:name":"Brisbane City",
     "wof:parent_id":404541435,

--- a/data/101/935/721/101935721.geojson
+++ b/data/101/935/721/101935721.geojson
@@ -18,8 +18,8 @@
     "mps:latitude":-34.929075,
     "mps:longitude":138.602578,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
-    "mz:min_zoom":4.0,
+    "mz:is_current":1,
+    "mz:min_zoom":3.7,
     "name:afr_x_preferred":[
         "Adelaide"
     ],
@@ -580,6 +580,7 @@
         "gn:id":2078025,
         "gp:id":1099805,
         "loc:id":"n80037938",
+        "ne:id":1159151165,
         "nyt:id":"59013514176757517981",
         "qs_pg:id":351591,
         "wd:id":"Q5112",
@@ -612,7 +613,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1607462631,
+    "wof:lastmodified":1608688179,
     "wof:megacity":1,
     "wof:name":"Adelaide",
     "wof:parent_id":404544867,

--- a/data/101/937/679/101937679.geojson
+++ b/data/101/937/679/101937679.geojson
@@ -18,8 +18,8 @@
     "mps:latitude":-31.960773,
     "mps:longitude":115.834088,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
-    "mz:min_zoom":4.0,
+    "mz:is_current":1,
+    "mz:min_zoom":3.7,
     "name:afr_x_preferred":[
         "Perth"
     ],
@@ -587,6 +587,7 @@
         "fct:id":"033eab20-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2063523,
         "gp:id":1098081,
+        "ne:id":1159151475,
         "nyt:id":"71341963227653029801",
         "qs_pg:id":138000,
         "wd:id":"Q3183",
@@ -616,7 +617,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1607462604,
+    "wof:lastmodified":1608688187,
     "wof:megacity":1,
     "wof:name":"Perth",
     "wof:parent_id":404548115,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary